### PR TITLE
Replace "Html" with "HTML" in summary/value text

### DIFF
--- a/xml/System.Net.Mail/MailMessage.xml
+++ b/xml/System.Net.Mail/MailMessage.xml
@@ -920,9 +920,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets a value indicating whether the mail message body is in Html.</summary>
+        <summary>Gets or sets a value indicating whether the mail message body is in HTML.</summary>
         <value>
-          <see langword="true" /> if the message body is in Html; else <see langword="false" />. The default is <see langword="false" />.</value>
+          <see langword="true" /> if the message body is in HTML; else <see langword="false" />. The default is <see langword="false" />.</value>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
Replaced "Html" with "HTML" in summary/value text for MailMessage.IsBodyHtml property.
